### PR TITLE
Fixed 'mask2' in setDataStreaming.

### DIFF
--- a/lib/commands/api.js
+++ b/lib/commands/api.js
@@ -108,7 +108,7 @@ exports.setDataStreaming = function(sensorRateDivisor, frames, mask, packetCount
   packet.DATA.writeUInt32BE(mask, 4);
   packet.DATA.writeUInt8(packetCount, 8);
   if (mask2) {
-    packet.DATA.writeUInt32BE(sensorRateDivisor, 9);
+    packet.DATA.writeUInt32BE(mask2, 9);
   }
   var result = packetBuilder(packet);
   return result;


### PR DESCRIPTION
Wrong variable was being written instead of mask2, preventing streaming of Locator X, Y, velocities, etc.
