### PR TITLE
Typo in examples/vege.js and commands/macro.js

### DIFF
--- a/examples/vege.js
+++ b/examples/vege.js
@@ -20,7 +20,7 @@ var colourStart = 0x006600;
 var colourStop = 0x00FF00;
 
 s.on('open', function() {
-  s.write(commands.api.setStabalisation(false));
+  s.write(commands.api.setStabilisation(false));
 
   var step = 0;
   var steps = 30*1;

--- a/lib/commands/macro.js
+++ b/lib/commands/macro.js
@@ -1,7 +1,7 @@
 /* jshint node:true */
 
 
-exports.setStabalization = function(flag, postCommandDelay) {
+exports.setStabilization = function(flag, postCommandDelay) {
   var buffer = new Buffer(3);
   buffer.writeUInt8(0x03, 0);
   buffer.writeUInt8(flag, 1);


### PR DESCRIPTION
Typo in `commands.api.setStabilisation` and in macro.
