### PR TITLE
update to newest serialport

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Use your javascript powers to control the Sphero by Orbotix",
   "main": "lib/index.js",
   "dependencies": {
-    "serialport": "1.3.x"
+    "serialport": "^1.7.4"
   },
   "devDependencies": {
     "grunt": "~0.4.1",


### PR DESCRIPTION
this should take care of compile related issues like #12 as newer versions of serialport download the binary component as a `post_install` step.
